### PR TITLE
Refactor to Spring Data JDBC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <artifactId>spring-boot-starter-data-jdbc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/ru/asmsoft/search/service/SearchService.java
+++ b/src/main/java/ru/asmsoft/search/service/SearchService.java
@@ -5,12 +5,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
+import org.springframework.data.relational.core.query.CriteriaDefinition;
+import org.springframework.data.relational.core.query.Query;
 import ru.asmsoft.search.model.Pager;
 import ru.asmsoft.search.model.SearchQuery;
 import ru.asmsoft.search.model.SearchResult;
@@ -19,18 +22,18 @@ import ru.asmsoft.search.specification.SpecificationBuilder;
 /**
  * Search service.
  */
-public abstract class SearchService<T, R extends JpaSpecificationExecutor<T>> {
+public abstract class SearchService<T> {
 
-  private final R repository;
+  private final JdbcAggregateTemplate jdbcAggregateTemplate;
   private final Class<T> entityClass;
 
   /**
    * Search service constructor.
    *
-   * @param repository repository to use for search
+   * @param jdbcAggregateTemplate aggregate template to use for search
    */
-  protected SearchService(R repository) {
-    this.repository = repository;
+  protected SearchService(JdbcAggregateTemplate jdbcAggregateTemplate) {
+    this.jdbcAggregateTemplate = jdbcAggregateTemplate;
     this.entityClass =
         (Class<T>)
             ((ParameterizedType) getClass().getGenericSuperclass()).getActualTypeArguments()[0];
@@ -78,10 +81,23 @@ public abstract class SearchService<T, R extends JpaSpecificationExecutor<T>> {
             sort
     );
 
-    Specification<T> specification = new SpecificationBuilder<>(entityClass)
+    CriteriaDefinition criteriaDefinition = new SpecificationBuilder<>(entityClass)
             .build(query);
 
-    Page<T> page = repository.findAll(specification, pageRequest);
+    Query querySpecification = Query.query(criteriaDefinition)
+        .sort(sort)
+        .limit(pager.getSize())
+        .offset((long) pager.getPage() * pager.getSize());
+
+    List<T> items =
+        StreamSupport.stream(
+                jdbcAggregateTemplate.findAll(querySpecification, entityClass).spliterator(),
+                false)
+            .toList();
+
+    long total = jdbcAggregateTemplate.count(Query.query(criteriaDefinition), entityClass);
+
+    Page<T> page = new PageImpl<>(items, pageRequest, total);
 
     return SearchResult.of(page, pager);
   }

--- a/src/main/java/ru/asmsoft/search/specification/CustomSpecification.java
+++ b/src/main/java/ru/asmsoft/search/specification/CustomSpecification.java
@@ -1,15 +1,13 @@
 package ru.asmsoft.search.specification;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.relational.core.query.Criteria;
+import org.springframework.data.relational.core.query.CriteriaDefinition;
 import ru.asmsoft.search.model.Condition;
 import ru.asmsoft.search.model.Operations;
 
@@ -21,51 +19,48 @@ import ru.asmsoft.search.model.Operations;
 @Getter
 @Setter
 @RequiredArgsConstructor
-public class CustomSpecification<T> implements Specification<T> {
+public class CustomSpecification<T> {
 
   /** Conditions list. */
   private final List<Condition<? extends Comparable<?>>> conditions;
 
   /**
-   * Build Predicate from parameters.
+   * Build Criteria from parameters.
    *
-   * @param root from root
-   * @param builder criteria builder
    * @param condition condition to handle
-   * @return Predicate
-   * @param <T> the type of Root
+   * @return Criteria
    * @param <E> the type of Condition
    */
-  private static <T, E extends Comparable<E>> Predicate fromCondition(
-      Root<T> root, CriteriaBuilder builder, Condition<E> condition) {
+  private static <E extends Comparable<E>> Criteria fromCondition(Condition<E> condition) {
     switch (condition.getOperator()) {
       case Operations.EQUALS:
-        return builder.equal(root.get(condition.getField()), condition.getValue());
+        return Criteria.where(condition.getField()).is(condition.getValue());
       case Operations.NOT_EQUALS:
-        return builder.notEqual(root.get(condition.getField()), condition.getValue());
+        return Criteria.where(condition.getField()).not(condition.getValue());
       case Operations.LIKE:
-        return builder.like(root.get(condition.getField()), (String) condition.getValue());
+        return Criteria.where(condition.getField()).like(condition.getValue().toString());
       case Operations.GREATER:
-        return builder.greaterThan(root.get(condition.getField()), condition.getValue());
+        return Criteria.where(condition.getField()).greaterThan(condition.getValue());
       case Operations.LESS:
-        return builder.lessThan(root.get(condition.getField()), condition.getValue());
+        return Criteria.where(condition.getField()).lessThan(condition.getValue());
       case Operations.GREATER_OR_EQUALS:
-        return builder.greaterThanOrEqualTo(root.get(condition.getField()), condition.getValue());
+        return Criteria.where(condition.getField()).greaterThanOrEquals(condition.getValue());
       case Operations.LESS_OR_EQUALS:
-        return builder.lessThanOrEqualTo(root.get(condition.getField()), condition.getValue());
+        return Criteria.where(condition.getField()).lessThanOrEquals(condition.getValue());
       case Operations.IN:
-        return root.get(condition.getField()).in(condition.getValues());
+        return Criteria.where(condition.getField()).in(condition.getValues());
       default:
         return null;
     }
   }
 
   /**
-   * {@inheritDoc}
+   * Create {@link CriteriaDefinition} based on provided conditions.
+   *
+   * @return built {@link CriteriaDefinition}
    */
-  @Override
-  public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
-    final AtomicReference<Predicate> result = new AtomicReference<>(builder.conjunction());
+  public CriteriaDefinition toCriteria() {
+    final AtomicReference<Criteria> result = new AtomicReference<>();
     conditions.stream()
         .filter(
             condition ->
@@ -75,18 +70,29 @@ public class CustomSpecification<T> implements Specification<T> {
                     && (condition.getValue() != null || condition.getValues() != null))
         .forEach(
             condition -> {
-              Predicate p = fromCondition(root, builder, condition);
+              Criteria criteria = fromCondition(condition);
+              if (criteria == null) {
+                return;
+              }
+
+              if (result.get() == null) {
+                result.set(criteria);
+                return;
+              }
+
+              Criteria current = result.get();
               switch (condition.getExpression()) {
                 case AND:
-                  result.set(builder.and(result.get(), p));
+                  result.set(current.and(criteria));
                   break;
                 case OR:
-                  result.set(builder.or(result.get(), p));
+                  result.set(current.or(criteria));
                   break;
                 default:
                   // NOP
               }
             });
-    return result.get();
+
+    return Objects.requireNonNullElseGet(result.get(), Criteria::empty);
   }
 }

--- a/src/main/java/ru/asmsoft/search/specification/SpecificationBuilder.java
+++ b/src/main/java/ru/asmsoft/search/specification/SpecificationBuilder.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.relational.core.query.CriteriaDefinition;
 import ru.asmsoft.search.model.Condition;
 import ru.asmsoft.search.model.SearchQuery;
 
@@ -56,7 +56,7 @@ public class SpecificationBuilder<T> {
    * @param query the search query
    * @return Specification
    */
-  public Specification<T> build(SearchQuery query) {
+  public CriteriaDefinition build(SearchQuery query) {
     final Map<String, Class<?>> fields = extractFields();
     if (query.getConditions() != null) {
       conditions.addAll(
@@ -66,7 +66,7 @@ public class SpecificationBuilder<T> {
                       condition.into(fields.get(condition.getField())))
               .toList());
     }
-    return new CustomSpecification<>(conditions);
+    return new CustomSpecification<>(conditions).toCriteria();
   }
 
   private Map<String, Class<?>> extractFields() {


### PR DESCRIPTION
## Summary
- replace Spring Data JPA with Spring Data JDBC dependency
- refactor search service to execute queries via JdbcAggregateTemplate and relational criteria
- rebuild specification utilities to generate JDBC-compatible criteria definitions

## Testing
- mvn -q test *(fails: unable to download parent POM from Maven Central; received HTTP 403)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694287c2bfe08323a25db79549a17651)